### PR TITLE
Expose flag to emit the readonly attribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# force top-most EditorConfig file
+root = true
+
+# Windows-style newlines with no newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,coffee,litcoffee}]
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ md.render('[ ] unchecked') // =>
 
 md.render('[x] checked') // =>
 // <p>
-//  <input type="checkbox" id="checkbox0" checked="true">
+//  <input type="checkbox" id="checkbox0" checked="">
 //  <label for="checkbox0">checked</label>
 // </p>
 ```
@@ -47,13 +47,14 @@ var md = require('markdown-it')()
             .use(require('markdown-it-checkbox'),{
               divWrap: true,
               divClass: 'cb',
-              idPrefix: 'cbx_'
+              idPrefix: 'cbx_',
+              readonly: true
             });
 
 md.render('[ ] unchecked') // =>
 // <p>
 //  <div classname="cb">
-//    <input type="checkbox" id="cbx_0">
+//    <input type="checkbox" id="cbx_0" readonly="">
 //    <label for="cbx_0">unchecked</label>
 //  </div>
 // </p>
@@ -80,6 +81,12 @@ classname of div wrapper. will only be used if `divWrap` is enanbled.
 
 the id of the checkboxs input contains the prefix and an incremental number starting with `0`. i.e. `checkbox1` for the 2nd checkbox.
 
+## readonly
+
+* **Type:** `Boolean`
+* **Default:** `false`
+
+set the `input` to be `readonly`. this ensures that users cannot toggle the checkbox in the browser.
 
 ## License
 

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -30,7 +30,7 @@ gulp.task 'coffee', ->
 
 # remove `index.js` and `coverage` dir
 gulp.task 'clean', (cb) ->
-  del ['dist', 'coverage', 'temp'], cb
+  del ['dist', 'coverage', 'temp', 'index.js'], cb
 
 # run tests
 gulp.task 'test', ['coffee'], ->

--- a/index.coffee
+++ b/index.coffee
@@ -1,8 +1,23 @@
+# Utility functions
 _ = require 'underscore'
 
-# Checkbox replacement logic.
-#
+Array.prototype.move = (element, offset) ->
+  index = this.indexOf(element)
+  # if not found, return immediately
+  return index if index < 0
 
+  newIndex = index + offset
+  newIndex = 0 if newIndex < 0
+  newIndex = this.length - 1 if newIndex >= this.length
+
+  # remove the element from the array
+  removedElement = this.splice(index, 1)[0]
+  # at newIndex, remove 0 elements, insert the removedElement
+  this.splice newIndex, 0, removedElement
+  #return the newIndex of the removedElement
+  return newIndex
+
+# Checkbox replacement logic.
 checkboxReplace = (md, options, Token) ->
   "use strict"
 
@@ -100,6 +115,33 @@ checkboxReplace = (md, options, Token) ->
           tokens, i, splitTextToken(token, state.Token)
         )
         i--
+      j++
+
+    j = 0
+    l = blockTokens.length
+    while j < l
+      if blockTokens[j].type != "inline"
+        j++
+        continue
+      tokens = blockTokens[j].children
+      mappedTokens = tokens.map (t, idx) -> {
+        idx: idx
+        type: t.type
+        token: t
+      }
+      suitableIdx = tokens.length - 1
+
+      labelOpens = mappedTokens.filter (t) -> t.type is 'label_open'
+      for open in labelOpens.reverse()
+        if suitableIdx < 0 then suitableIdx = 0
+        while mappedTokens[suitableIdx].type in ['softbreak','checkbox_close']
+          suitableIdx--
+
+        labelClose = mappedTokens.find (t, idx) ->
+          open.idx < idx <= suitableIdx && t.type is 'label_close'
+        tokens.move labelClose.token, suitableIdx - labelClose.idx
+
+        suitableIdx = open.idx - 2
       j++
     return
 

--- a/index.coffee
+++ b/index.coffee
@@ -12,6 +12,7 @@ checkboxReplace = (md, options, Token) ->
     divWrap: false
     divClass: 'checkbox'
     idPrefix: 'checkbox'
+    readonly: false
 
   options = _.extend defaults, options
   pattern = /\[(X|\s|\_|\-)\]\s(.*)/i
@@ -28,14 +29,16 @@ checkboxReplace = (md, options, Token) ->
       nodes.push token
 
     ###*
-    # <input type="checkbox" id="checkbox{n}" checked="true">
+    # <input type="checkbox" id="checkbox{n}" checked="" readonly="">
     ###
     id = options.idPrefix + lastId
     lastId += 1
     token = new Token("checkbox_input", "input", 0)
     token.attrs = [["type","checkbox"],["id",id]]
     if(checked == true)
-      token.attrs.push ["checked","true"]
+      token.attrs.push ["checked", ""]
+    if options.readonly
+      token.attrs.push ["readonly", ""]
     nodes.push token
 
     ###*

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ checkboxReplace = function(md, options, Token) {
   defaults = {
     divWrap: false,
     divClass: 'checkbox',
-    idPrefix: 'checkbox'
+    idPrefix: 'checkbox',
+    readonly: false
   };
   options = _.extend(defaults, options);
   pattern = /\[(X|\s|\_|\-)\]\s(.*)/i;
@@ -28,14 +29,17 @@ checkboxReplace = function(md, options, Token) {
     }
 
     /**
-     * <input type="checkbox" id="checkbox{n}" checked="true">
+     * <input type="checkbox" id="checkbox{n}" checked="" readonly="">
      */
     id = options.idPrefix + lastId;
     lastId += 1;
     token = new Token("checkbox_input", "input", 0);
     token.attrs = [["type", "checkbox"], ["id", id]];
     if (checked === true) {
-      token.attrs.push(["checked", "true"]);
+      token.attrs.push(["checked", ""]);
+    }
+    if (options.readonly) {
+      token.attrs.push(["readonly", ""]);
     }
     nodes.push(token);
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,24 @@ var _, checkboxReplace;
 
 _ = require('underscore');
 
+Array.prototype.move = function(element, offset) {
+  var index, newIndex, removedElement;
+  index = this.indexOf(element);
+  if (index < 0) {
+    return index;
+  }
+  newIndex = index + offset;
+  if (newIndex < 0) {
+    newIndex = 0;
+  }
+  if (newIndex >= this.length) {
+    newIndex = this.length - 1;
+  }
+  removedElement = this.splice(index, 1)[0];
+  this.splice(newIndex, 0, removedElement);
+  return newIndex;
+};
+
 checkboxReplace = function(md, options, Token) {
   "use strict";
   var arrayReplaceAt, createTokens, defaults, lastId, pattern, splitTextToken;
@@ -82,7 +100,7 @@ checkboxReplace = function(md, options, Token) {
     return createTokens(checked, label, Token);
   };
   return function(state) {
-    var blockTokens, i, j, l, token, tokens;
+    var blockTokens, i, j, k, l, labelClose, labelOpens, len, mappedTokens, open, ref, ref1, suitableIdx, token, tokens;
     blockTokens = state.tokens;
     j = 0;
     l = blockTokens.length;
@@ -97,6 +115,42 @@ checkboxReplace = function(md, options, Token) {
         token = tokens[i];
         blockTokens[j].children = tokens = arrayReplaceAt(tokens, i, splitTextToken(token, state.Token));
         i--;
+      }
+      j++;
+    }
+    j = 0;
+    l = blockTokens.length;
+    while (j < l) {
+      if (blockTokens[j].type !== "inline") {
+        j++;
+        continue;
+      }
+      tokens = blockTokens[j].children;
+      mappedTokens = tokens.map(function(t, idx) {
+        return {
+          idx: idx,
+          type: t.type,
+          token: t
+        };
+      });
+      suitableIdx = tokens.length - 1;
+      labelOpens = mappedTokens.filter(function(t) {
+        return t.type === 'label_open';
+      });
+      ref = labelOpens.reverse();
+      for (k = 0, len = ref.length; k < len; k++) {
+        open = ref[k];
+        if (suitableIdx < 0) {
+          suitableIdx = 0;
+        }
+        while ((ref1 = mappedTokens[suitableIdx].type) === 'softbreak' || ref1 === 'checkbox_close') {
+          suitableIdx--;
+        }
+        labelClose = mappedTokens.find(function(t, idx) {
+          return (open.idx < idx && idx <= suitableIdx) && t.type === 'label_close';
+        });
+        tokens.move(labelClose.token, suitableIdx - labelClose.idx);
+        suitableIdx = open.idx - 2;
       }
       j++;
     }

--- a/test/fixtures/checkbox.txt
+++ b/test/fixtures/checkbox.txt
@@ -31,3 +31,84 @@
 <li><input type="checkbox" id="checkbox5" checked=""><label for="checkbox5">checked</label></li>
 </ul>
 .
+
+.
+[ ] unchecked *with* **markdown**
+[ ] unchecked *with* markdown
+[X] checked ~~with~~ [markdown]()
+.
+<p><input type="checkbox" id="checkbox8"><label for="checkbox8">unchecked <em>with</em> <strong>markdown</strong></label>
+<input type="checkbox" id="checkbox7"><label for="checkbox7">unchecked <em>with</em> markdown</label>
+<input type="checkbox" id="checkbox6" checked=""><label for="checkbox6">checked <s>with</s> <a href="">markdown</a></label></p>
+.
+
+.
+> [ ] unchecked *with* **markdown**
+> > Rather replace with:
+> > [ ] unchecked *with* **markdown**
+> >					```
+> >					var block = 'and a code block';
+> >					```
+> > [X] checked ~~with~~ [markdown]()
+.
+<blockquote>
+<p><input type="checkbox" id="checkbox9"><label for="checkbox9">unchecked <em>with</em> <strong>markdown</strong></label></p>
+<blockquote>
+<p>Rather replace with:
+<input type="checkbox" id="checkbox11"><label for="checkbox11">unchecked <em>with</em> <strong>markdown</strong>
+<code>var block = 'and a code block';</code></label>
+<input type="checkbox" id="checkbox10" checked=""><label for="checkbox10">checked <s>with</s> <a href="">markdown</a></label></p>
+</blockquote>
+</blockquote>
+.
+
+.
+- [ ] unchecked *with* **markdown**
+- [X] checked ~~with~~ [markdown]()
+.
+<ul>
+<li><input type="checkbox" id="checkbox12"><label for="checkbox12">unchecked <em>with</em> <strong>markdown</strong></label></li>
+<li><input type="checkbox" id="checkbox13" checked=""><label for="checkbox13">checked <s>with</s> <a href="">markdown</a></label></li>
+</ul>
+.
+
+.
+ Col1              | Col2               | Col3
+-------------------|--------------------|-----------------
+ [ ]               | no label           | not a checkbox
+ [x] text          | without            | markdown
+ [ ] test *markup* | with               | markdown
+ only one checkbox | rest are the label | [X] [ ] [x] [_]
+.
+<table>
+<thead>
+<tr>
+<th>Col1</th>
+<th>Col2</th>
+<th>Col3</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>[ ]</td>
+<td>no label</td>
+<td>not a checkbox</td>
+</tr>
+<tr>
+<td><input type="checkbox" id="checkbox14" checked=""><label for="checkbox14">text</label></td>
+<td>without</td>
+<td>markdown</td>
+</tr>
+<tr>
+<td><input type="checkbox" id="checkbox15"><label for="checkbox15">test <em>markup</em></label></td>
+<td>with</td>
+<td>markdown</td>
+</tr>
+<tr>
+<td>only one checkbox</td>
+<td>rest are the label</td>
+<td><input type="checkbox" id="checkbox16" checked=""><label for="checkbox16">[ ] [x] [_]</label></td>
+</tr>
+</tbody>
+</table>
+.

--- a/test/fixtures/checkbox.txt
+++ b/test/fixtures/checkbox.txt
@@ -13,13 +13,13 @@
 .
 [x] checked
 .
-<p><input type="checkbox" id="checkbox2" checked="true"><label for="checkbox2">checked</label></p>
+<p><input type="checkbox" id="checkbox2" checked=""><label for="checkbox2">checked</label></p>
 .
 
 .
 [X] checked
 .
-<p><input type="checkbox" id="checkbox3" checked="true"><label for="checkbox3">checked</label></p>
+<p><input type="checkbox" id="checkbox3" checked=""><label for="checkbox3">checked</label></p>
 .
 
 .
@@ -28,6 +28,6 @@
 .
 <ul>
 <li><input type="checkbox" id="checkbox4"><label for="checkbox4">unchecked</label></li>
-<li><input type="checkbox" id="checkbox5" checked="true"><label for="checkbox5">checked</label></li>
+<li><input type="checkbox" id="checkbox5" checked=""><label for="checkbox5">checked</label></li>
 </ul>
 .

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -63,3 +63,18 @@ describe 'markdown-it-checkbox', ->
         '<label for="checkbox0">test written</label>' +
         '</p>\n'
       done()
+
+  describe 'markdown-it-checkbox() with nested markdown', ->
+    plugin = require '../'
+    md = require('markdown-it')()
+    md.use plugin, {divWrap: false}
+
+    it 'should encapsulate subsequent content', (done) ->
+      res = md.render('[X] test *written* ~~in~~ ' +
+                          '**markdown** and [followed]() with content')
+      res.toString().should.be.eql '<p>' +
+        '<input type="checkbox" id="checkbox0" checked="">' +
+        '<label for="checkbox0">test <em>written</em> <s>in</s> ' +
+        '<strong>markdown</strong> and <a href="">followed</a> with content' +
+        '</label></p>\n'
+      done()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -20,36 +20,46 @@ describe 'markdown-it-checkbox', ->
   describe 'markdown-it-checkbox(options)', ->
     plugin = require('../')
 
-    it 'should should optionally wrap arround a div layer', (done) ->
+    it 'should optionally wrap arround a div layer', (done) ->
       md = require('markdown-it')()
       md.use plugin, {divWrap: true}
       res = md.render('[X] test written')
       res.toString().should.be.eql '<p>' +
         '<div class="checkbox">' +
-        '<input type="checkbox" id="checkbox0" checked="true">' +
+        '<input type="checkbox" id="checkbox0" checked="">' +
         '<label for="checkbox0">test written</label>' +
         '</div>' +
         '</p>\n'
       done()
 
-    it 'should should optionally change class of div layer', (done) ->
+    it 'should optionally change class of div layer', (done) ->
       md = require('markdown-it')()
       md.use plugin, {divWrap: true, divClass: 'cb'}
       res = md.render('[X] test written')
       res.toString().should.be.eql '<p>' +
         '<div class="cb">' +
-        '<input type="checkbox" id="checkbox0" checked="true">' +
+        '<input type="checkbox" id="checkbox0" checked="">' +
         '<label for="checkbox0">test written</label>' +
         '</div>' +
         '</p>\n'
       done()
 
-    it 'should should optionally change the id', (done) ->
+    it 'should optionally change the id', (done) ->
       md = require('markdown-it')()
       md.use plugin, {idPrefix: 'cb'}
       res = md.render('[X] test written')
       res.toString().should.be.eql '<p>' +
-        '<input type="checkbox" id="cb0" checked="true">' +
+        '<input type="checkbox" id="cb0" checked="">' +
         '<label for="cb0">test written</label>' +
+        '</p>\n'
+      done()
+
+    it 'should optionally be readonly', (done) ->
+      md = require('markdown-it')()
+      md.use plugin, {readonly: true}
+      res = md.render('[X] test written')
+      res.toString().should.be.eql '<p>' +
+        '<input type="checkbox" id="checkbox0" checked="" readonly="">' +
+        '<label for="checkbox0">test written</label>' +
         '</p>\n'
       done()


### PR DESCRIPTION
- aligned input attributes (checked, readonly) with W3C standards (http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes)
- updated README.md
- fixed test naming